### PR TITLE
Configurable hostname and port for gulp command using command line parameters or env variables.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "gulp-uglify": "1.1.0",
     "karma-jasmine": "~0.3.1",
     "karma-phantomjs-launcher": "~0.1.4",
+    "minimist": "~1.1.1",
     "require-dir": "~0.1.0",
     "wiredep": "~2.2.0"
   },

--- a/src/rest/hawkRest-alert-provider.spec.rest.js
+++ b/src/rest/hawkRest-alert-provider.spec.rest.js
@@ -16,7 +16,10 @@ describe('Provider: Hawkular Alerts live REST', function() {
     });
   };
 
-  beforeEach(module('hawkular.services', 'httpReal'));
+  beforeEach(module('hawkular.services', 'httpReal', function(HawkularAlertProvider) {
+    HawkularAlertProvider.setHost(__karma__.config.hostname);
+    HawkularAlertProvider.setPort(__karma__.config.port);
+  }));
 
   beforeEach(inject(function(_HawkularAlert_, _$resource_, _httpReal_, _$http_) {
     HawkularAlert = _HawkularAlert_;

--- a/src/rest/hawkRest-inventory-provider.spec.rest.js
+++ b/src/rest/hawkRest-inventory-provider.spec.rest.js
@@ -16,7 +16,10 @@ describe('Provider: Hawkular live REST', function() {
     });
   };
 
-  beforeEach(module('hawkular.services', 'httpReal'));
+  beforeEach(module('hawkular.services', 'httpReal', function(HawkularInventoryProvider) {
+    HawkularInventoryProvider.setHost(__karma__.config.hostname);
+    HawkularInventoryProvider.setPort(__karma__.config.port);
+  }));
 
   beforeEach(inject(function(_HawkularInventory_, _$resource_, _httpReal_, _$http_) {
     HawkularInventory = _HawkularInventory_;

--- a/src/rest/hawkRest-metric-factory.spec.rest.js
+++ b/src/rest/hawkRest-metric-factory.spec.rest.js
@@ -3,7 +3,10 @@ describe('Provider: Hawkular live REST', function() {
   var HawkularMetric;
   var httpReal;
 
-  beforeEach(module('hawkular.services', 'httpReal'));
+  beforeEach(module('hawkular.services', 'httpReal', function(HawkularMetricProvider) {
+    HawkularMetricProvider.setHost(__karma__.config.hostname);
+    HawkularMetricProvider.setPort(__karma__.config.port);
+  }));
 
   beforeEach(inject(function(_HawkularMetric_, _httpReal_) {
     HawkularMetric = _HawkularMetric_;


### PR DESCRIPTION
This PR introduces a way to run the tests against an arbitrary Hawkular server instance by specifying the hostname and port from command line:
`gulp rest:inventory --hostname 127.0.0.2 --port 8081` or 
`gulp rest:inventory --hostname=127.0.0.2 --port=8081` or
`export HAWKULAR_TEST_PORT=8081 && export HAWKULAR_TEST_HOSTNAME=127.0.0.2 && gulp rest:inventory` or
any combination of above-mentioned.

If not specified, port defaults to **8080** and hostname to **localhost**.
