### PR TITLE
HWKINVENT-121 | Do not encode path parameters in ui-services ($resource)

### DIFF
--- a/src/rest/hawkRest-inventory-provider.ts
+++ b/src/rest/hawkRest-inventory-provider.ts
@@ -23,6 +23,34 @@
 
 module hawkularRest {
 
+  _module.constant("inventoryInterceptURLS",
+      [new RegExp('.+/inventory/.+/resources/.+%2F.+')]);
+
+  _module.config(['$httpProvider', 'inventoryInterceptURLS', function($httpProvider, inventoryInterceptURLS) {
+    var ENCODED_SLASH = new RegExp("%2F", 'g');
+
+    $httpProvider.interceptors.push(function ($q) {
+      return {
+        'request': function (config) {
+          var url = config.url;
+
+          for (var i = 0; i < inventoryInterceptURLS.length; i++) {
+
+            if (url.match(inventoryInterceptURLS[i])) {
+              url = url.replace(ENCODED_SLASH, "/");
+              // end there is only one matching url
+              break;
+            }
+          }
+
+          config.url = url;
+          return config || $q.when(config);
+        }
+      };
+    });
+  }]);
+
+
   _module.provider('HawkularInventory', function() {
 
     this.setProtocol = function(protocol) {


### PR DESCRIPTION
https://issues.jboss.org/browse/HWKINVENT-121

This can be also done by adding specific query parameter in $resource and filter by that parameter and replace %2F to /.

Filtering should match only URLs where this replace is needed otherwise it can lead to 
ambiguous behavior. 
