### PR TITLE
Alerts 0.4.x

### DIFF
--- a/src/rest/hawkRest-alert-provider.spec.rest.js
+++ b/src/rest/hawkRest-alert-provider.spec.rest.js
@@ -1,34 +1,12 @@
-describe('Provider: Hawkular Alerts live REST', function() {
+describe('Provider: Hawkular Alerts live REST =>', function() {
 
   var HawkularAlert;
   var res;
   var httpReal;
   var $http;
+  var $q;
 
-  var debug = false;
-  var suffix = '-test-' + new Date().getTime();
-  var triggerId = 'test-rest-trigger-200' + suffix;
-  var triggerId2 = 'test-rest-trigger-100' + suffix;
-  var triggerId3 = 'test-rest-trigger-1' + suffix;
-  var triggerId4 = 'test-rest-trigger-2' + suffix;
-  var triggerId5 = 'test-rest-trigger-3' + suffix;
-  var triggerId6 = 'test-rest-trigger-4' + suffix;
-  var triggerId7 = 'test-rest-trigger-5' + suffix;
-  var triggerName = 'No-Metric-Name' + suffix;
-  var triggerName2 = 'No-Metric-Name-Modified';
-  var dampeningId = 'test-rest-trigger-100' + suffix + '-FIRE';
-  var actionId = 'test-notifier-email-1' + suffix;
-
-  var restResolve = function(result, done){
-    httpReal.submit();
-
-    result.$promise.then(function(){
-    }, function(error){
-      fail(errorFn(error));
-    }).finally(function(){
-      done();
-    });
-  };
+  var debug = true;
 
   beforeEach(module('hawkular.services', 'httpReal', function(HawkularAlertProvider) {
 
@@ -37,982 +15,738 @@ describe('Provider: Hawkular Alerts live REST', function() {
 
   }));
 
-  beforeEach(inject(function(_HawkularAlert_, _$resource_, _httpReal_, _$http_) {
+  beforeEach(inject(function(_HawkularAlert_, _$resource_, _httpReal_, _$http_, _$q_) {
     HawkularAlert = _HawkularAlert_;
     res = _$resource_;
     httpReal = _httpReal_;
     $http = _$http_;
+    $q = _$q_;
+
+    // it assumes we are running the tests against the hawkular built with -Pdev profile
+    // 'amRvZTpwYXNzd29yZA==' ~ jdoe:password in base64
+    $http.defaults.headers.common['Authorization'] = 'Basic amRvZTpwYXNzd29yZA==';
   }));
 
+  describe('Create a Garbage Collection Alert definition', function() {
 
-  describe('Alerts:', function() {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
 
-    describe('get list of alerts', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
+    var newTrigger = {
+      id: 'thevault~local-jvm-garbage-collection-trigger',
+      name: 'JVM Garbage Collection for thevault~Local',
+      autoResolve: true,
+      autoResolveAlerts: true,
+      context: {
+        resourceType: 'App Server',
+        resourceName: 'thevault~Local'
+      }
+    };
 
-      beforeEach(function(done) {
-        result = HawkularAlert.Alert.query();
-        restResolve(result, done);
+    var newDampening = {
+      triggerId: newTrigger.id,
+      triggerMode: 'FIRING',
+      type: 'STRICT_TIME',
+      evalTrueSetting: 0,
+      evalTotalSetting: 0,
+      evalTimeSetting: 10000
+    };
+
+    var newFiringConditions = [
+      {
+        triggerId: newTrigger.id,
+        triggerMode: 'FIRING',
+        type: 'THRESHOLD',
+        dataId: 'thevault~local-jvm-garbage-collection-data-id',
+        operator: 'GT',
+        threshold: 1000,
+        context: {
+          description: 'GC Duration',
+          unit: 'ms'
+        }
+      }
+    ];
+
+    var newAutoResolveConditions = [
+      {
+        triggerId: newTrigger.id,
+        triggerMode: 'AUTORESOLVE',
+        type: 'THRESHOLD',
+        dataId: 'thevault~local-jvm-garbage-collection-data-id',
+        operator: 'LTE',
+        threshold: 1000,
+        context: {
+          description: 'GC Duration',
+          unit: 'ms'
+        }
+      }
+    ];
+
+    var created;
+
+    beforeEach(function(done) {
+
+      // Delete previous test data
+      HawkularAlert.Trigger.delete({triggerId: newTrigger.id}).$promise.finally(function() {
+
+           HawkularAlert.Trigger.save(newTrigger).$promise.then(
+             // Success Trigger save
+             function(trigger) {
+               debug && dump(JSON.stringify(trigger));
+               return HawkularAlert.Dampening.save({triggerId: trigger.id},
+                 newDampening).$promise;
+             },
+             // Error Trigger save
+             function(errorTrigger) {
+               errorFn(errorTrigger);
+               return $q.reject('Error on Trigger save');
+             }
+           ).then(
+              // Success Dampening save
+              function(dampening) {
+                debug && dump(JSON.stringify(dampening));
+                return HawkularAlert.Conditions.save({triggerId: newTrigger.id,
+                  triggerMode: 'FIRING'},
+                  newFiringConditions).$promise;
+              },
+             // Error Dampening save
+             function (errorDampening) {
+               errorFn(errorDampening);
+               return $q.reject('Error on Dampening save');
+             }
+           ).then(
+              // Success Firing Conditions save
+             function(firingConditions) {
+               debug && dump(JSON.stringify(firingConditions));
+               return HawkularAlert.Conditions.save({triggerId: newTrigger.id,
+                triggerMode: 'AUTORESOLVE'},
+                newAutoResolveConditions).$promise;
+             },
+             // Error Firing Conditions save
+             function(errorFiringConditions) {
+               errorFn(errorFiringConditions);
+             }
+           ).then(
+              // Success AutoResolve Conditions save
+             function(autoResolveConditions) {
+               debug && dump(JSON.stringify(autoResolveConditions));
+              created = autoResolveConditions;
+             },
+             // Error AutoResolve Conditions save
+             function(errorAutoResolveConditions) {
+               errorFn(errorAutoResolveConditions);
+             }
+           ).finally(function() {
+               done();
+           });
+
       });
 
-      it ('should resolve', function() {
-        expect(result.$resolved).toEqual(true);
-      });
-
+      httpReal.submit();
     });
 
-    describe('invoke a reload operation', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Alert.reload();
-        restResolve(result, done);
-      });
-
-      it ('should resolve', function() {
-        expect(result.$resolved).toEqual(true);
-      });
-
-    });
-
-  });
-
-  describe('Definitions - Triggers: ', function() {
-
-    describe('creating a trigger definition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        var trigger = {
-          name: triggerName,
-          description: 'Test description',
-          actions: ['uno', 'dos', 'tres'],
-          firingMatch: 'ALL',
-          safetyMatch: 'ALL',
-          id: triggerId,
-          enabled: true,
-          safetyEnabled: true
-        };
-        result = HawkularAlert.Trigger.save(trigger);
-        restResolve(result, done);
-      });
-
-      it ('should resolve and return created trigger', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.name).toEqual(triggerName);
-        expect(result.description).toEqual('Test description');
-        expect(result.actions.length).toEqual(3);
-        expect(result.actions[0]).toEqual('uno');
-        expect(result.actions[1]).toEqual('dos');
-        expect(result.actions[2]).toEqual('tres');
-        expect(result.firingMatch).toEqual('ALL');
-        expect(result.safetyMatch).toEqual('ALL');
-        expect(result.id).toEqual(triggerId);
-        expect(result.enabled).toEqual(true);
-        expect(result.safetyEnabled).toEqual(true);
-      });
-    });
-
-    var triggerToUpdate;
-
-    describe('get an existing trigger definition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Trigger.get({triggerId: triggerId});
-        restResolve(result, done);
-      });
-
-      it ('should get previously created trigger', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.name).toEqual(triggerName);
-        expect(result.description).toEqual('Test description');
-        expect(result.actions.length).toEqual(3);
-        expect(result.actions[0]).toEqual('uno');
-        expect(result.actions[1]).toEqual('dos');
-        expect(result.actions[2]).toEqual('tres');
-        expect(result.firingMatch).toEqual('ALL');
-        expect(result.safetyMatch).toEqual('ALL');
-        expect(result.id).toEqual(triggerId);
-        expect(result.enabled).toEqual(true);
-        expect(result.safetyEnabled).toEqual(true);
-
-        triggerToUpdate = result;
-      });
-    });
-
-    describe('update an existing trigger', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-
-        triggerToUpdate.name = triggerName2;
-        result = HawkularAlert.Trigger.put({triggerId: triggerToUpdate.id}, triggerToUpdate);
-        restResolve(result, done);
-      });
-
-      it ('should resolve', function() {
-        expect(result.$resolved).toEqual(true);
-      });
-    });
-
-    describe('get an updated trigger', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Trigger.get({triggerId: triggerId});
-        restResolve(result, done);
-      });
-
-      it ('should get previously created trigger', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.name).toEqual(triggerName2);
-        expect(result.description).toEqual('Test description');
-        expect(result.actions.length).toEqual(3);
-        expect(result.actions[0]).toEqual('uno');
-        expect(result.actions[1]).toEqual('dos');
-        expect(result.actions[2]).toEqual('tres');
-        expect(result.firingMatch).toEqual('ALL');
-        expect(result.safetyMatch).toEqual('ALL');
-        expect(result.id).toEqual(triggerId);
-        expect(result.enabled).toEqual(true);
-        expect(result.safetyEnabled).toEqual(true);
-
-      });
-    });
-
-    describe('get a trigger list', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Trigger.query();
-        restResolve(result, done);
-      });
-
-      it ('should get a minimum array of one', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.length).toBeGreaterThan(0);
-      });
-    });
-
-    describe('delete a trigger definition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Trigger.delete({triggerId: triggerId});
-        restResolve(result, done);
-      });
-
-      it ('should resolve', function() {
-        expect(result.$resolved).toEqual(true);
-      });
+    it('should create a trigger correctly', function() {
+      // We test last step create correctly AUTORESOLVE conditions
+      expect(created.length).toEqual(newAutoResolveConditions.length);
     });
 
   });
 
-  describe('Definitions - Dampenings:' , function() {
+  describe('Create a JVM Alert definition with multiple conditions', function() {
 
-    describe('creating a dampening definition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
 
-      beforeEach(function(done) {
-        var dampening = {
-          triggerId: triggerId2,
-          triggerMode: 'FIRE',
-          type: 'STRICT',
-          evalTrueSetting: 1,
-          evalTotalSetting: 1,
-          evalTimeSetting: 100
-        };
-        result = HawkularAlert.Dampening.save({triggerId: dampening.triggerId}, dampening);
-        restResolve(result, done);
+    var newTrigger = {
+      id: 'thevault~local-web-multiple-jvm-metrics-trigger',
+      name: 'Multiple JVM Metrics for thevault~Local',
+      autoResolve: true,
+      autoResolveAlerts: true,
+      context: {
+        resourceType: 'App Server',
+        resourceName: 'thevault~Local',
+        category: 'JVM'
+      }
+    };
+
+    var newDampening = {
+      triggerId: newTrigger.id,
+      triggerMode: 'FIRING',
+      type: 'STRICT_TIME',
+      evalTrueSetting: 0,
+      evalTotalSetting: 0,
+      evalTimeSetting: 10000
+    };
+
+    var newFiringConditions = [
+      {
+        triggerId: newTrigger.id,
+        triggerMode: 'FIRING',
+        conditionSetSize: 3,
+        conditionSetIndex: 1,
+        type: 'THRESHOLD',
+        dataId: 'thevault~local-jvm-garbage-collection-data-id',
+        operator: 'GT',
+        threshold: 1000,
+        context: {
+          description: 'GC Duration',
+          unit: 'ms'
+        }
+      },
+      {
+        triggerId: newTrigger.id,
+        triggerMode: 'FIRING',
+        conditionSetSize: 3,
+        conditionSetIndex: 2,
+        type: 'RANGE',
+        dataId: 'thevault~local-jvm-heap-usage-data-id',
+        operatorLow: 'INCLUSIVE',
+        operatorHigh: 'INCLUSIVE',
+        thresholdLow: 100,
+        thresholdHigh: 300,
+        inRange: true,
+        context: {
+          description: 'Heap Usage',
+          unit: 'Mb'
+        }
+      },
+      {
+        triggerId: newTrigger.id,
+        triggerMode: 'FIRING',
+        conditionSetSize: 3,
+        conditionSetIndex: 3,
+        type: 'RANGE',
+        dataId: 'thevault~local-jvm-non-heap-usage-data-id',
+        operatorLow: 'INCLUSIVE',
+        operatorHigh: 'INCLUSIVE',
+        thresholdLow: 100,
+        thresholdHigh: 200,
+        inRange: true,
+        context: {
+          description: 'Non Heap Usage',
+          unit: 'Mb'
+        }
+      }
+    ];
+
+    var newAutoResolveConditions = [
+      {
+        triggerId: newTrigger.id,
+        triggerMode: 'AUTORESOLVE',
+        conditionSetSize: 3,
+        conditionSetIndex: 1,
+        type: 'THRESHOLD',
+        dataId: 'thevault~local-jvm-garbage-collection-data-id',
+        operator: 'LTE',
+        threshold: 1000,
+        context: {
+          description: 'GC Duration',
+          unit: 'ms'
+        }
+      },
+      {
+        triggerId: newTrigger.id,
+        triggerMode: 'AUTORESOLVE',
+        conditionSetSize: 3,
+        conditionSetIndex: 2,
+        type: 'RANGE',
+        dataId: 'thevault~local-jvm-heap-usage-data-id',
+        operatorLow: 'EXCLUSIVE',
+        operatorHigh: 'EXCLUSIVE',
+        thresholdLow: 100,
+        thresholdHigh: 300,
+        inRange: false,
+        context: {
+          description: 'Heap Usage',
+          unit: 'Mb'
+        }
+      },
+      {
+        triggerId: newTrigger.id,
+        triggerMode: 'AUTORESOLVE',
+        conditionSetSize: 3,
+        conditionSetIndex: 3,
+        type: 'RANGE',
+        dataId: 'thevault~local-jvm-non-heap-usage-data-id',
+        operatorLow: 'EXCLUSIVE',
+        operatorHigh: 'EXCLUSIVE',
+        thresholdLow: 100,
+        thresholdHigh: 200,
+        inRange: false,
+        context: {
+          description: 'Non Heap Usage',
+          unit: 'Mb'
+        }
+      }
+    ];
+
+    var created;
+
+    beforeEach(function(done) {
+
+      // Delete previous test data
+      HawkularAlert.Trigger.delete({triggerId: newTrigger.id}).$promise.finally(function() {
+
+        HawkularAlert.Trigger.save(newTrigger).$promise.then(
+          // Success Trigger save
+          function(trigger) {
+            debug && dump(JSON.stringify(trigger));
+            return HawkularAlert.Dampening.save({triggerId: trigger.id},
+              newDampening).$promise;
+          },
+          // Error Trigger save
+          function(errorTrigger) {
+            debug && dump(errorFn(errorTrigger));
+            return $q.reject('Error on Trigger save');
+          }
+        ).then(
+          // Success Dampening save
+          function(dampening) {
+            debug && dump(JSON.stringify(dampening));
+            return HawkularAlert.Conditions.save({triggerId: newTrigger.id,
+                triggerMode: 'FIRING'},
+              newFiringConditions).$promise;
+          },
+          // Error Dampening save
+          function (errorDampening) {
+            debug && dump(errorFn(errorDampening));
+            return $q.reject('Error on Dampening save');
+          }
+        ).then(
+          // Success Firing Conditions save
+          function(firingConditions) {
+            debug && dump(JSON.stringify(firingConditions));
+            return HawkularAlert.Conditions.save({triggerId: newTrigger.id,
+                triggerMode: 'AUTORESOLVE'},
+              newAutoResolveConditions).$promise;
+          },
+          // Error Firing Conditions save
+          function(errorFiringConditions) {
+            debug && dump(errorFn(errorFiringConditions));
+          }
+        ).then(
+          // Success AutoResolve Conditions save
+          function(autoResolveConditions) {
+            debug && dump(JSON.stringify(autoResolveConditions));
+            created = autoResolveConditions;
+          },
+          // Error AutoResolve Conditions save
+          function(errorAutoResolveConditions) {
+            debug && dump(errorFn(errorAutoResolveConditions));
+          }
+        ).finally(function() {
+            done();
+          });
+
       });
 
-      it ('should resolve and return created dampening', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.triggerId).toEqual(triggerId2);
-        expect(result.triggerMode).toEqual('FIRE');
-        expect(result.type).toEqual('STRICT');
-        expect(result.evalTrueSetting).toEqual(1);
-        expect(result.evalTotalSetting).toEqual(1);
-        expect(result.evalTimeSetting).toEqual(100);
-        expect(result.dampeningId).toEqual(dampeningId);
-      });
+      httpReal.submit();
     });
 
-    var dampeningToUpdate;
-
-    describe('get an existing dampening definition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Dampening.get({triggerId: triggerId2, dampeningId: dampeningId});
-        restResolve(result, done);
-      });
-
-      it ('should get previously created dampening', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.triggerId).toEqual(triggerId2);
-        expect(result.triggerMode).toEqual('FIRE');
-        expect(result.type).toEqual('STRICT');
-        expect(result.evalTrueSetting).toEqual(1);
-        expect(result.evalTotalSetting).toEqual(1);
-        expect(result.evalTimeSetting).toEqual(100);
-        expect(result.dampeningId).toEqual(dampeningId);
-
-        dampeningToUpdate = result;
-      });
-    });
-
-    describe('update an existing dampening', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        dampeningToUpdate.type = 'STRICT_TIME';
-        result = HawkularAlert.Dampening.put({triggerId: dampeningToUpdate.triggerId,
-          dampeningId: dampeningToUpdate.dampeningId}, dampeningToUpdate);
-        restResolve(result, done);
-      });
-
-      it ('should resolve', function() {
-        expect(result.$resolved).toEqual(true);
-      });
-    });
-
-    describe('get an updated dampening', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Dampening.get({triggerId: triggerId2,
-          dampeningId: dampeningId});
-        restResolve(result, done);
-      });
-
-      it ('should get previously created dampening', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.triggerId).toEqual(triggerId2);
-        expect(result.triggerMode).toEqual('FIRE');
-        expect(result.type).toEqual('STRICT_TIME');
-        expect(result.evalTrueSetting).toEqual(1);
-        expect(result.evalTotalSetting).toEqual(1);
-        expect(result.evalTimeSetting).toEqual(100);
-        expect(result.dampeningId).toEqual(dampeningId);
-      });
-    });
-
-    describe('get a dampening list', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Dampening.query({triggerId: triggerId2});
-        restResolve(result, done);
-      });
-
-      it ('should get a minimum array of one', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.length).toBeGreaterThan(0);
-      });
-    });
-
-    describe('delete a dampening definition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Dampening.delete({triggerId: triggerId2,
-          dampeningId: dampeningId});
-        restResolve(result, done);
-      });
-
-      it ('should resolve', function() {
-        expect(result.$resolved).toEqual(true);
-      });
-    });
-
-  });
-
-  describe('Definitions - Conditions - Availability: ', function() {
-
-    describe('creating an availability condition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-
-        var availabilityCondition = {
-          triggerId: triggerId3,
-          dataId: 'No-Metric',
-          type: 'AVAILABILITY',
-          operator: 'NOT_UP'
-        };
-
-        result = HawkularAlert.Condition.save({triggerId: triggerId3}, availabilityCondition);
-        restResolve(result, done);
-      });
-
-      it ('should resolve and return created condition', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.length).toEqual(1);
-        expect(result[0].operator).toEqual('NOT_UP');
-      });
-    });
-
-    var conditionToUpdate;
-
-    describe('get an existing availability condition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Condition.query({triggerId: triggerId3});
-        restResolve(result, done);
-      });
-
-      it ('should get previously created availability condition', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.length).toEqual(1);
-        expect(result[0].triggerId).toEqual(triggerId3);
-        expect(result[0].operator).toEqual('NOT_UP');
-
-        conditionToUpdate = result[0];
-      });
-    });
-
-    describe('update an existing availability condition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        conditionToUpdate.operator = 'DOWN';
-        result = HawkularAlert.Condition.put({triggerId: conditionToUpdate.triggerId,
-          conditionId: conditionToUpdate.conditionId}, conditionToUpdate);
-        restResolve(result, done);
-      });
-
-      it ('should resolve', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.length).toEqual(1);
-        expect(result[0].triggerId).toEqual(triggerId3);
-        expect(result[0].operator).toEqual('DOWN');
-      });
-    });
-
-    describe('get an updated availability condition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Condition.get({triggerId: conditionToUpdate.triggerId,
-          conditionId: conditionToUpdate.conditionId});
-        restResolve(result, done);
-      });
-
-      it ('should get previously created availability condition', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.triggerId).toEqual(triggerId3);
-        expect(result.operator).toEqual('DOWN');
-      });
-    });
-
-    describe('delete an availability condition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Condition.delete({triggerId: conditionToUpdate.triggerId,
-          conditionId: conditionToUpdate.conditionId});
-        restResolve(result, done);
-      });
-
-      it ('should resolve', function() {
-        expect(result.$resolved).toEqual(true);
-      });
+    it('should create a trigger correctly', function() {
+      // We test last step create correctly AUTORESOLVE conditions
+      expect(created.length).toEqual(newAutoResolveConditions.length);
     });
 
   });
 
-  describe('Definitions - Conditions - Compare: ', function() {
+  describe('Modify an existing definition adding conditions', function() {
 
-    describe('creating a compare condition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
 
-      beforeEach(function(done) {
-        var compareCondition = {
-          triggerId: triggerId4,
-          type: 'COMPARE',
-          dataId: 'No-Metric-1',
-          operator: 'LT',
-          data2Multiplier: 1.0,
-          data2Id: 'No-Metric-2'
-        };
+    var updateTriggerId = 'thevault~local-web-multiple-jvm-metrics-trigger';
 
-        result = HawkularAlert.Condition.save({triggerId: triggerId4}, compareCondition);
-        restResolve(result, done);
+    var updateFiringConditions = [
+      {
+        triggerId: updateTriggerId,
+        triggerMode: 'FIRING',
+        conditionSetSize: 7,
+        conditionSetIndex: 1,
+        type: 'THRESHOLD',
+        dataId: 'thevault~local-jvm-garbage-collection-data-id',
+        operator: 'GT',
+        threshold: 1000,
+        context: {
+          description: 'GC Duration',
+          unit: 'ms'
+        }
+      },
+      {
+        triggerId: updateTriggerId,
+        triggerMode: 'FIRING',
+        conditionSetSize: 7,
+        conditionSetIndex: 2,
+        type: 'RANGE',
+        dataId: 'thevault~local-jvm-heap-usage-data-id',
+        operatorLow: 'INCLUSIVE',
+        operatorHigh: 'INCLUSIVE',
+        thresholdLow: 100,
+        thresholdHigh: 300,
+        inRange: true,
+        context: {
+          description: 'Heap Usage',
+          unit: 'Mb'
+        }
+      },
+      {
+        triggerId: updateTriggerId,
+        triggerMode: 'FIRING',
+        conditionSetSize: 7,
+        conditionSetIndex: 3,
+        type: 'RANGE',
+        dataId: 'thevault~local-jvm-non-heap-usage-data-id',
+        operatorLow: 'INCLUSIVE',
+        operatorHigh: 'INCLUSIVE',
+        thresholdLow: 100,
+        thresholdHigh: 200,
+        inRange: true,
+        context: {
+          description: 'Non Heap Usage',
+          unit: 'Mb'
+        }
+      },
+      {
+        triggerId: updateTriggerId,
+        triggerMode: 'FIRING',
+        conditionSetSize: 7,
+        conditionSetIndex: 4,
+        type: 'AVAILABILITY',
+        dataId: 'thevault~local-test-availability-data-id',
+        operator: 'DOWN',
+        context: {
+          description: 'Availability'
+        }
+      },
+      {
+        triggerId: updateTriggerId,
+        triggerMode: 'FIRING',
+        conditionSetSize: 7,
+        conditionSetIndex: 5,
+        type: 'COMPARE',
+        dataId: 'thevault~local-test-compare-data-id',
+        operator: 'LTE',
+        dataId2: 'thevault~local-test-compare-data-id-2',
+        data2Multiplier: 0.5,
+        context: {
+          description: 'Heap',
+          description2: 'Non Heap'
+        }
+      },
+      {
+        triggerId: updateTriggerId,
+        triggerMode: 'FIRING',
+        conditionSetSize: 7,
+        conditionSetIndex: 6,
+        type: 'EXTERNAL',
+        systemId: 'TestSystemId',
+        dataId: 'thevault~local-test-external-data-id',
+        expression: 'TestExpression'
+      },
+      {
+        triggerId: updateTriggerId,
+        triggerMode: 'FIRING',
+        conditionSetSize: 7,
+        conditionSetIndex: 7,
+        type: 'STRING',
+        dataId: 'thevault~local-test-string-data-id',
+        operator: 'STARTS_WITH',
+        pattern: 'www.',
+        ignoreCase: false,
+        context: {
+          description: 'URL'
+        }
+      }
+    ];
+
+    var updatedConditions;
+
+    beforeEach(function(done) {
+      HawkularAlert.Conditions.save({triggerId: updateTriggerId,
+        triggerMode: 'FIRING'}, updateFiringConditions).$promise.then(
+          // Successful Conditions save
+          function(firingConditions) {
+            debug && dump(JSON.stringify(firingConditions));
+            updatedConditions = firingConditions;
+          },
+          // Error Conditions save
+        function(errorFiringConditions) {
+          debug && dump(errorFn(errorFiringConditions));
+        }
+      ).finally(function() {
+          done();
       });
 
-      it ('should resolve and return created condition', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.length).toEqual(1);
-        expect(result[0].operator).toEqual('LT');
-        expect(result[0].data2Id).toEqual('No-Metric-2');
-      });
+      httpReal.submit();
     });
 
-    var conditionToUpdate;
-
-    describe('get an existing compare condition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Condition.query({triggerId: triggerId4});
-        restResolve(result, done);
-      });
-
-      it ('should get previously created compare condition', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.length).toEqual(1);
-        expect(result[0].operator).toEqual('LT');
-        expect(result[0].data2Id).toEqual('No-Metric-2');
-
-        conditionToUpdate = result[0];
-      });
-    });
-
-    describe('update an existing compare condition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        conditionToUpdate.operator = 'GT';
-        result = HawkularAlert.Condition.put({triggerId: conditionToUpdate.triggerId,
-          conditionId: conditionToUpdate.conditionId}, conditionToUpdate);
-        restResolve(result, done);
-      });
-
-      it ('should resolve', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.length).toEqual(1);
-        expect(result[0].operator).toEqual('GT');
-        expect(result[0].data2Id).toEqual('No-Metric-2');
-      });
-    });
-
-    describe('get an updated compare condition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Condition.get({triggerId: conditionToUpdate.triggerId,
-          conditionId: conditionToUpdate.conditionId});
-        restResolve(result, done);
-      });
-
-      it ('should get previously created compare condition', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.triggerId).toEqual(triggerId4);
-        expect(result.operator).toEqual('GT');
-      });
-    });
-
-    describe('delete a compare condition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Condition.delete({triggerId: conditionToUpdate.triggerId,
-          conditionId: conditionToUpdate.conditionId});
-        restResolve(result, done);
-      });
-
-      it ('should resolve', function() {
-        expect(result.$resolved).toEqual(true);
-      });
-    });
-
-  });
-
-  describe('Definitions - Conditions - String: ', function() {
-
-    describe('creating a string condition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        var stringCondition = {
-          triggerId: triggerId5,
-          type: 'STRING',
-          dataId: 'No-Metric',
-          operator: 'EQUAL',
-          pattern: 'pattern-test',
-          ignoreCase: 'false'
-        };
-
-        result = HawkularAlert.Condition.save({triggerId: triggerId5}, stringCondition);
-        restResolve(result, done);
-      });
-
-      it ('should resolve and return created condition', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.length).toEqual(1);
-        expect(result[0].triggerId).toEqual(triggerId5);
-        expect(result[0].operator).toEqual('EQUAL');
-        expect(result[0].pattern).toEqual('pattern-test');
-      });
-    });
-
-    var conditionToUpdate;
-
-    describe('get an existing string condition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Condition.query({triggerId: triggerId5});
-        restResolve(result, done);
-      });
-
-      it ('should get previously created string condition', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.length).toEqual(1);
-        expect(result[0].triggerId).toEqual(triggerId5);
-        expect(result[0].operator).toEqual('EQUAL');
-        expect(result[0].pattern).toEqual('pattern-test');
-
-        conditionToUpdate = result[0];
-      });
-    });
-
-    describe('update an existing string condition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        conditionToUpdate.operator = 'ENDS_WITH';
-        result = HawkularAlert.Condition.put({triggerId: conditionToUpdate.triggerId,
-          conditionId: conditionToUpdate.conditionId}, conditionToUpdate);
-        restResolve(result, done);
-      });
-
-      it ('should resolve', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result[0].triggerId).toEqual(triggerId5);
-        expect(result[0].operator).toEqual('ENDS_WITH');
-        expect(result[0].pattern).toEqual('pattern-test');
-      });
-    });
-
-    describe('get an updated string condition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Condition.get({triggerId: conditionToUpdate.triggerId,
-          conditionId: conditionToUpdate.conditionId});
-        restResolve(result, done);
-      });
-
-      it ('should get previously created string condition', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.triggerId).toEqual(triggerId5);
-        expect(result.operator).toEqual('ENDS_WITH');
-      });
-    });
-
-    describe('delete an string condition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Condition.delete({triggerId: conditionToUpdate.triggerId,
-          conditionId: conditionToUpdate.conditionId});
-        restResolve(result, done);
-      });
-
-      it ('should resolve', function() {
-        expect(result.$resolved).toEqual(true);
-      });
+    it('should update conditions correctly', function() {
+      // We test last step create correctly AUTORESOLVE conditions
+      expect(updatedConditions.length).toEqual(updateFiringConditions.length);
     });
 
   });
 
-  describe('Definitions - Conditions - Threshold: ', function() {
+  describe('Retrieve an existing definition', function() {
 
-    describe('creating a threshold condition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
 
-      beforeEach(function(done) {
-        var thresholdCondition = {
-          triggerId: triggerId6,
-          type: 'THRESHOLD',
-          dataId: 'No-Metric',
-          operator: 'LT',
-          threshold: 15.0
-        };
+    var existingTriggerId = 'thevault~local-web-multiple-jvm-metrics-trigger';
 
-        result = HawkularAlert.Condition.save({triggerId: triggerId6}, thresholdCondition);
-        restResolve(result, done);
+    var resultTrigger = [];
+
+    beforeEach(function(done) {
+      HawkularAlert.Trigger.get({triggerId: existingTriggerId}).$promise.then(
+        // Successful Trigger get
+        function(trigger) {
+          debug && dump(JSON.stringify(trigger));
+          resultTrigger['trigger'] = trigger;
+          return HawkularAlert.Dampening.query({triggerId: existingTriggerId}).$promise;
+        },
+        // Error Trigger get
+        function(errorTrigger) {
+          debug && dump(errorFn(errorTrigger));
+          return $q.reject('Error on Trigger query');
+        }
+      ).then(
+        // Successful Dampening query
+        function(dampenings) {
+          debug && dump(JSON.stringify(dampenings));
+          resultTrigger['dampenings'] = dampenings;
+          return HawkularAlert.Conditions.query({triggerId: existingTriggerId}).$promise;
+        },
+        // Error Dampening query
+        function(errorDampenings) {
+          debug && dump(errorFn(errorDampenings));
+          return $q.reject('Error on Dampening query');
+        }
+      ).then(
+        // Successful Conditions query
+        function(conditions) {
+          debug && dump(JSON.stringify(conditions));
+          resultTrigger['conditions'] = conditions;
+        },
+        // Error Conditions query
+        function(errorConditions) {
+          debug && dump(errorFn(errorConditions));
+        }
+      ).finally(function() {
+        done();
       });
 
-      it ('should resolve and return created condition', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.length).toEqual(1);
-        expect(result[0].triggerId).toEqual(triggerId6);
-        expect(result[0].operator).toEqual('LT');
-        expect(result[0].threshold).toEqual(15.0);
-      });
+      httpReal.submit();
     });
 
-    var conditionToUpdate;
-
-    describe('get an existing threshold condition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Condition.query({triggerId: triggerId6});
-        restResolve(result, done);
-      });
-
-      it ('should get previously created threshold condition', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.length).toEqual(1);
-        expect(result[0].triggerId).toEqual(triggerId6);
-        expect(result[0].operator).toEqual('LT');
-        expect(result[0].threshold).toEqual(15.0);
-
-        conditionToUpdate = result[0];
-      });
-    });
-
-    describe('update an existing threshold condition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        conditionToUpdate.operator = 'GTE';
-        result = HawkularAlert.Condition.put({triggerId: conditionToUpdate.triggerId,
-          conditionId: conditionToUpdate.conditionId}, conditionToUpdate);
-        restResolve(result, done);
-      });
-
-      it ('should resolve', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.length).toEqual(1);
-        expect(result[0].triggerId).toEqual(triggerId6);
-        expect(result[0].operator).toEqual('GTE');
-        expect(result[0].threshold).toEqual(15.0);
-      });
-    });
-
-    describe('get an updated threshold condition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Condition.get({triggerId: conditionToUpdate.triggerId,
-          conditionId: conditionToUpdate.conditionId});
-        restResolve(result, done);
-      });
-
-      it ('should get previously created threshold condition', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.triggerId).toEqual(triggerId6);
-        expect(result.operator).toEqual('GTE');
-      });
-    });
-
-    describe('delete an threshold condition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Condition.delete({triggerId: conditionToUpdate.triggerId,
-          conditionId: conditionToUpdate.conditionId});
-        restResolve(result, done);
-      });
-
-      it ('should resolve', function() {
-        expect(result.$resolved).toEqual(true);
-      });
+    it('should retrieve full trigger correctly', function() {
+      expect(resultTrigger['trigger'].id).toEqual(existingTriggerId);
+      expect(resultTrigger['dampenings'].length).toEqual(1);
+      expect(resultTrigger['conditions'].length).toEqual(10);
     });
 
   });
 
-  describe('Definitions - Conditions - Range: ', function() {
+  describe('Get a list of ActionPlugins', function() {
 
-    describe('creating a range condition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
 
-      beforeEach(function(done) {
-        var rangeCondition = {
-          triggerId: triggerId7,
-          type: 'RANGE',
-          dataId: 'No-Metric',
-          operatorLow: 'INCLUSIVE',
-          operatorHigh: 'EXCLUSIVE',
-          thresholdLow: 10.51,
-          thresholdHigh: 10.99,
-          inRange: true
-        };
+    var resultPlugins;
 
-        result = HawkularAlert.Condition.save({triggerId: triggerId7}, rangeCondition);
-        restResolve(result, done);
+    beforeEach(function(done) {
+      HawkularAlert.ActionPlugin.query().$promise.then(
+        // Successful ActionPlugin query
+        function(plugins) {
+          debug && dump(JSON.stringify(plugins));
+          resultPlugins = plugins;
+        },
+        // Error ActionPlugin query
+        function(errorPlugins) {
+          debug && dump(errorFn(errorPlugins));
+        }
+      ).finally(function() {
+          done();
       });
 
-      it ('should resolve and return created condition', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.length).toEqual(1);
-        expect(result[0].triggerId).toEqual(triggerId7);
-        expect(result[0].operatorLow).toEqual('INCLUSIVE');
-        expect(result[0].thresholdHigh).toEqual(10.99);
-      });
+      httpReal.submit();
     });
 
-    var conditionToUpdate;
-
-    describe('get an existing range condition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Condition.query({triggerId: triggerId7});
-        restResolve(result, done);
-      });
-
-      it ('should get previously created range condition', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.length).toEqual(1);
-        expect(result[0].triggerId).toEqual(triggerId7);
-        expect(result[0].operatorLow).toEqual('INCLUSIVE');
-        expect(result[0].thresholdHigh).toEqual(10.99);
-
-        conditionToUpdate = result[0];
-      });
-    });
-
-    describe('update an existing threshold condition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        conditionToUpdate.operatorLow = 'EXCLUSIVE';
-        result = HawkularAlert.Condition.put({triggerId: conditionToUpdate.triggerId,
-          conditionId: conditionToUpdate.conditionId}, conditionToUpdate);
-        restResolve(result, done);
-      });
-
-      it ('should resolve', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.length).toEqual(1);
-        expect(result[0].triggerId).toEqual(triggerId7);
-        expect(result[0].operatorLow).toEqual('EXCLUSIVE');
-        expect(result[0].thresholdHigh).toEqual(10.99);
-      });
-    });
-
-    describe('get an updated range condition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Condition.get({triggerId: conditionToUpdate.triggerId,
-          conditionId: conditionToUpdate.conditionId});
-        restResolve(result, done);
-      });
-
-      it ('should get previously created range condition', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.triggerId).toEqual(triggerId7);
-        expect(result.operatorLow).toEqual('EXCLUSIVE');
-      });
-    });
-
-    describe('delete an range condition', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Condition.delete({triggerId: conditionToUpdate.triggerId,
-          conditionId: conditionToUpdate.conditionId});
-        restResolve(result, done);
-      });
-
-      it ('should resolve', function() {
-        expect(result.$resolved).toEqual(true);
-      });
+    it ('should get more than one action plugin', function() {
+      expect(resultPlugins.length).toBeGreaterThan(0);
     });
 
   });
 
-  describe('Definitions - Action Plugins: ', function() {
+  describe('Get a specific ActionPlugin', function() {
 
-    describe('get a list of Action Plugins', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
 
-      beforeEach(function(done) {
-        result = HawkularAlert.ActionPlugin.query();
-        restResolve(result, done);
+    var resultPlugin;
+
+    beforeEach(function(done) {
+      HawkularAlert.ActionPlugin.get({actionPlugin : 'email'}).$promise.then(
+        // Succesful ActionPlugin get
+        function(plugin) {
+          debug && dump(JSON.stringify(plugin));
+          resultPlugin = plugin;
+        },
+        // Error ActionPlugin get
+        function(errorPlugin) {
+          debug && dump(errorFn(errorPlugin));
+        }
+      ).finally(function() {
+        done();
       });
 
-      it ('should get more than one action plugin', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.length).toBeGreaterThan(0);
-      });
-
+      httpReal.submit();
     });
 
-    describe('get a specific Action Plugin', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.ActionPlugin.get({actionPlugin : 'email'});
-        restResolve(result, done);
-      });
-
-      it ('should get action plugin properties', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.length).toBeGreaterThan(0);
-      });
-
+    it ('should get ActionPlugin properties', function() {
+      expect(resultPlugin.length).toBeGreaterThan(0);
     });
 
   });
 
-  describe('Definitions - Actions: ', function() {
+  describe('Create an email action', function() {
 
-    describe('creating a new action ', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
 
-      beforeEach(function(done) {
-        var action = {
-          actionId: actionId,
-          actionPlugin: 'email',
-          prop1: 'value1',
-          prop2: 'value2',
-          prop3: 'value3'
-        };
+    var newAction = {
+      actionPlugin: 'email',
+      actionId: 'email-to-test-sysadmins-group',
+      to: 'test-sysadmins@test-organization.org',
+      cc: 'developers@test-organization.org',
+      'cc.resolved': 'cio@test-organization.org'
+    };
 
-        result = HawkularAlert.Action.save(action);
-        restResolve(result, done);
+    var resultAction;
+
+    beforeEach(function(done) {
+
+      // Delete previous test data
+      HawkularAlert.Action.delete({pluginId: newAction.actionPlugin,
+        actionId: newAction.actionId}).$promise.finally(function() {
+
+        HawkularAlert.Action.save(newAction).$promise.then(
+          // Succesful Action save
+          function(action) {
+            debug && dump(JSON.stringify(action));
+            resultAction = action;
+          },
+          // Error Action save
+          function(errorAction) {
+            debug && dump(errorFn(errorAction));
+          }
+        ).finally(function() {
+          done();
+        });
       });
 
-      it ('should resolve and return created action', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.actionId).toEqual(actionId);
-        expect(result.actionPlugin).toEqual('email');
-        expect(result.prop1).toEqual('value1');
-        expect(result.prop2).toEqual('value2');
-        expect(result.prop3).toEqual('value3');
-      });
+      httpReal.submit();
     });
 
-    var actionToUpdate;
-
-    describe('get an existing action ', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Action.get({actionId: actionId});
-        restResolve(result, done);
-      });
-
-      it ('should get previously created notifier', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.actionId).toEqual(actionId);
-        expect(result.actionPlugin).toEqual('email');
-        expect(result.prop1).toEqual('value1');
-        expect(result.prop2).toEqual('value2');
-        expect(result.prop3).toEqual('value3');
-
-        actionToUpdate = result;
-      });
-    });
-
-    describe('update an existing action ', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        actionToUpdate.prop1 = 'value1Modified';
-        result = HawkularAlert.Action.put({actionId: actionId}, actionToUpdate);
-        restResolve(result, done);
-      });
-
-      it ('should resolve', function() {
-        expect(result.$resolved).toEqual(true);
-      });
-    });
-
-    describe('get an updated action', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Action.get({actionId: actionId});
-        restResolve(result, done);
-      });
-
-      it ('should get previously created action', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.actionId).toEqual(actionId);
-        expect(result.actionPlugin).toEqual('email');
-        expect(result.prop1).toEqual('value1Modified');
-        expect(result.prop2).toEqual('value2');
-        expect(result.prop3).toEqual('value3');
-      });
-    });
-
-    describe('get a list of actions by plugin', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Action.plugin({actionPlugin: 'email'});
-        restResolve(result, done);
-      });
-
-      it ('should get previously created action', function() {
-        expect(result.$resolved).toEqual(true);
-        expect(result.length).toBeGreaterThan(0);
-      });
-    });
-
-
-    describe('delete an action', function() {
-      var result;
-      jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
-
-      beforeEach(function(done) {
-        result = HawkularAlert.Action.delete({actionId: actionId});
-        restResolve(result, done);
-      });
-
-      it ('should resolve', function() {
-        expect(result.$resolved).toEqual(true);
-      });
+    it ('should create an Action', function() {
+      expect(resultAction.actionId).toEqual(newAction.actionId);
     });
 
   });
 
+  describe('Update an existing action', function() {
+
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
+
+    var updateAction = {
+      actionPlugin: 'email',
+      actionId: 'email-to-test-sysadmins-group',
+      to: 'test-sysadmins@test-organization.org',
+      cc: 'developers@test-organization.org',
+      'cc.resolved': 'cio-updated@test-organization.org'
+    };
+
+    var resultAction;
+
+    beforeEach(function(done) {
+
+      HawkularAlert.Action.put({pluginId: updateAction.actionPlugin,
+        actionId: updateAction.actionId}, updateAction).$promise.then(
+        // Successful Action put
+        function(action) {
+          debug && dump(JSON.stringify(action));
+          resultAction = action;
+        },
+        // Error Action put
+        function(errorAction) {
+          debug && dump(errorFn(errorAction));
+        }
+      ).finally(function() {
+          done();
+      });
+
+      httpReal.submit();
+    });
+
+    it ('should update an Action', function() {
+      expect(resultAction['cc.resolved']).toEqual(updateAction['cc.resolved']);
+    });
+
+  });
+
+  describe('Get an updated action', function() {
+
+    var pluginId = 'email';
+    var actionId = 'email-to-test-sysadmins-group';
+
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
+
+    var resultAction;
+
+    beforeEach(function(done) {
+      HawkularAlert.Action.get({pluginId: pluginId, actionId: actionId}).$promise.then(
+        // Sucessful Action get
+        function(action) {
+          debug && dump(JSON.stringify(action));
+          resultAction = action;
+        },
+        // Error Action get
+        function(errorAction) {
+          debug && dump(errorFn(errorAction));
+        }
+      ).finally(function() {
+          done();
+      });
+
+      httpReal.submit();
+    });
+
+    it ('should get previously created action', function() {
+      expect(resultAction.actionId).toEqual(actionId);
+      expect(resultAction.actionPlugin).toEqual(pluginId);
+    });
+  });
+
+  describe('Get a list of actions by plugin', function() {
+
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
+
+    var resultActionsId;
+
+    beforeEach(function(done) {
+      result = HawkularAlert.Action.plugin({actionPlugin: 'email'}).$promise.then(
+        // Successful Action plugin
+        function(actionsId) {
+          debug && dump(JSON.stringify(actionsId));
+          resultActionsId = actionsId;
+        },
+        // Error Action plugin
+        function(errorActionsId) {
+          debug && dump(errorFn(errorActionsId));
+        }
+      ).finally(function() {
+          done();
+      });
+
+
+      httpReal.submit();
+    });
+
+    it ('should get list of actions of email plugin', function() {
+      expect(resultActionsId.length).toBeGreaterThan(0);
+    });
+  });
+  
 });

--- a/src/rest/hawkRest-alert-provider.spec.rest.js
+++ b/src/rest/hawkRest-alert-provider.spec.rest.js
@@ -616,7 +616,7 @@ describe('Provider: Hawkular Alerts live REST =>', function() {
       jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT;
 
       var triggerId = 'thevault~local-jvm-garbage-collection-trigger';
-      var resultPage;
+      var alert;
 
       beforeEach(function(done) {
 
@@ -637,12 +637,30 @@ describe('Provider: Hawkular Alerts live REST =>', function() {
             // Success, fetch
             function(alerts) {
               debug && dump(JSON.stringify(alerts));
-              resultPage = alerts;
+              if ( alerts.length != 1 ) {
+                  return $q.reject('Alert not found');
+              }
+              var alert = alerts[0];
+              return HawkularAlert.Alert.get({alertId:alert.alertId}).$promise;
             },
             // Error, fetch
             function (errorFetch) {
               errorFn(errorfetch);
               return $q.reject('Error on Alert Fetch');
+            }
+          ).then(
+            // Success, get
+            function(singleAlert) {
+              debug && dump(JSON.stringify(singleAlert));
+              if ( null == singleAlert ) {
+                return $q.reject('Alert not found');
+              }
+              alert = singleAlert;
+            },
+            // Error, get
+            function (errorFetch) {
+              errorFn(errorFetch);
+              return $q.reject('Error on Alert Get');
             }
           ).finally(function() {
             done();
@@ -652,7 +670,7 @@ describe('Provider: Hawkular Alerts live REST =>', function() {
       });
 
       it ('should get list of single alert', function() {
-        expect(resultPage.length).toBeGreaterThan(0);
+        expect(alert.status).toEqual('OPEN');
       });
 
     });

--- a/src/rest/hawkRest-alert-provider.ts
+++ b/src/rest/hawkRest-alert-provider.ts
@@ -51,8 +51,8 @@ module hawkularRest {
       var prefix = this.protocol + '://' + this.host + ':' + this.port;
       var factory: any = {};
 
-      factory.Alert = $resource(prefix + '/hawkular/alerts', {
-
+      factory.Alert = $resource(prefix + '/hawkular/alerts/alert/:alertId', {
+        alertId: '@alertId'
       }, {
         query: {
           method: 'GET',
@@ -62,10 +62,6 @@ module hawkularRest {
         delete: {
           method: 'PUT',
           url: prefix + '/hawkular/alerts/delete'
-        },
-        reload: {
-          method: 'GET',
-          url: prefix + '/hawkular/alerts/reload'
         },
         ack: {
           method: 'PUT',
@@ -98,13 +94,6 @@ module hawkularRest {
         },
         put: {
           method: 'PUT'
-        },
-        reload: {
-          method: 'GET',
-          url: prefix + '/hawkular/alerts/reload/:triggerId',
-          params: {
-            triggerId: '@triggerId'
-          }
         }
       });
 

--- a/src/rest/hawkRest-alert-provider.ts
+++ b/src/rest/hawkRest-alert-provider.ts
@@ -101,31 +101,22 @@ module hawkularRest {
         }
       });
 
-      factory.Condition = $resource(prefix + '/hawkular/alerts/triggers/:triggerId/conditions/:conditionId', {
-        triggerId: '@triggerId',
-        conditionId: '@conditionId'
+      factory.Conditions = $resource(prefix + '/hawkular/alerts/triggers/:triggerId/conditions/', {
+        triggerId: '@triggerId'
       }, {
-        get: {
-          method: 'GET',
-          url: prefix + '/hawkular/alerts/triggers/:triggerId/conditions/:conditionId'
-        },
         save: {
-          method: 'POST',
-          isArray: true,
-          url: prefix + '/hawkular/alerts/triggers/:triggerId/conditions/'
-        },
-        put: {
           method: 'PUT',
-          isArray: true
+          isArray: true,
+          url: prefix + '/hawkular/alerts/triggers/:triggerId/conditions/:triggerMode',
+          params: {
+            triggerId: '@triggerId',
+            triggerMode: '@triggerMode'
+          }
         },
         query: {
           method: 'GET',
           isArray: true,
           url: prefix + '/hawkular/alerts/triggers/:triggerId/conditions/'
-        },
-        delete: {
-          method: 'DELETE',
-          isArray: true
         }
       });
 

--- a/src/rest/hawkRest-alert-provider.ts
+++ b/src/rest/hawkRest-alert-provider.ts
@@ -54,13 +54,30 @@ module hawkularRest {
       factory.Alert = $resource(prefix + '/hawkular/alerts', {
 
       }, {
+        query: {
+          method: 'GET',
+          isArray: true,
+          url: prefix + '/hawkular/alerts'
+        },
+        delete: {
+          method: 'PUT',
+          url: prefix + '/hawkular/alerts/delete'
+        },
         reload: {
           method: 'GET',
           url: prefix + '/hawkular/alerts/reload'
         },
+        ack: {
+          method: 'PUT',
+          url: prefix + '/hawkular/alerts/ack'
+        },
         resolve: {
           method: 'PUT',
           url: prefix + '/hawkular/alerts/resolve'
+        },
+        send: {
+          method: 'POST',
+          url: prefix + '/hawkular/alerts/data'
         }
       });
 

--- a/src/rest/hawkRest-alert-provider.ts
+++ b/src/rest/hawkRest-alert-provider.ts
@@ -69,9 +69,17 @@ module hawkularRest {
         },
         ack: {
           method: 'PUT',
+          url: prefix + '/hawkular/alerts/ack/:alertId'
+        },
+        ackmany: {
+          method: 'PUT',
           url: prefix + '/hawkular/alerts/ack'
         },
         resolve: {
+          method: 'PUT',
+          url: prefix + '/hawkular/alerts/resolve/:alertId'
+        },
+        resolvemany: {
           method: 'PUT',
           url: prefix + '/hawkular/alerts/resolve'
         },


### PR DESCRIPTION
This PR updates HawkularAlert factories to newest Alerts 0.4.x version.
Some endpoints have been modified, important to mention that now conditions are treated as a block, instead of individual, this helps UI usecases where the link between form and HawkularAlert has more complexity.

So, to integrate these changes into hawkular, alerts 0.4.x should be upgraded in hawkular and UI code (mainly focus on alertsManager.ts) should be upgraded.

@mtho11 can you review, please ?

@jshaughn thanks for your contribution !
