### PR TITLE
HWKINVENT-65 Feeds moved from environments to tenants

### DIFF
--- a/dist/hawkular-ui-service.js
+++ b/dist/hawkular-ui-service.js
@@ -383,7 +383,7 @@ var hawkularRest;
                     },
                     relationships: relsActionFor(environmentUrl)
                 });
-                var feedUrl = url + '/:environmentId/feeds/:feedId';
+                var feedUrl = url + '/feeds/:feedId';
                 factory.Feed = $resource(feedUrl, null, {
                     put: {
                         method: 'PUT'
@@ -392,11 +392,11 @@ var hawkularRest;
                 });
                 var resourceUrl = url + '/:environmentId/resources/:resourcePath';
                 factory.Resource = $resource(resourceUrl, null, createResourceActions(resourceUrl, 'configuration'));
-                var feedResourceUrl = url + '/:environmentId/:feedId/resources/:resourcePath';
+                var feedResourceUrl = url + '/feeds/:feedId/resources/:resourcePath';
                 factory.ResourceUnderFeed = $resource(feedResourceUrl, null, createResourceActions(feedResourceUrl, 'configuration'));
                 var resourceTypeUrl = url + '/resourceTypes/:resourceTypeId';
                 factory.ResourceType = $resource(resourceTypeUrl, null, createDataActions(resourceTypeUrl, 'configurationSchema'));
-                var feedResourceTypeUrl = url + '/:environmentId/:feedId/resourceTypes/:resourceTypeId';
+                var feedResourceTypeUrl = url + '/feeds/:feedId/resourceTypes/:resourceTypeId';
                 factory.ResourceTypeUnderFeed = $resource(feedResourceTypeUrl, null, createDataActions(feedResourceTypeUrl, 'configurationSchema'));
                 var metricTypeUrl = url + '/metricTypes/:metricTypeId';
                 factory.MetricType = $resource(metricTypeUrl, null, {
@@ -405,7 +405,7 @@ var hawkularRest;
                     },
                     relationships: relsActionFor(metricTypeUrl)
                 });
-                var feedMetricTypeUrl = url + '/:environmentId/:feedId/metricTypes/:metricTypeId';
+                var feedMetricTypeUrl = url + '/feeds/:feedId/metricTypes/:metricTypeId';
                 factory.MetricTypeUnderFeed = $resource(feedMetricTypeUrl, null, {
                     put: {
                         method: 'PUT'
@@ -418,7 +418,7 @@ var hawkularRest;
                         method: 'PUT'
                     }
                 });
-                var feedResourceMetricUrl = url + '/:environmentId/:feedId/resources/:resourcePath/metrics/:metricId';
+                var feedResourceMetricUrl = url + '/feeds/:feedId/resources/:resourcePath/metrics/:metricId';
                 factory.MetricOfResourceUnderFeed = $resource(resourceMetricUrl, null, {
                     put: {
                         method: 'PUT'
@@ -428,16 +428,16 @@ var hawkularRest;
                 factory.MetricTypeOfResourceType = $resource(metricTypeOfResourceTypeUrl, null, {
                     relationships: relsActionFor(metricTypeOfResourceTypeUrl)
                 });
-                var feedMetricTypeOfResourceTypeUrl = url + '/:environmentId/:feedId/resourceTypes/:resourceTypeId/metricTypes/:metricTypeId';
+                var feedMetricTypeOfResourceTypeUrl = url + '/feeds/:feedId/resourceTypes/:resourceTypeId/metricTypes/:metricTypeId';
                 factory.MetricTypeOfResourceTypeUnderFeed = $resource(feedMetricTypeOfResourceTypeUrl, null, {
                     relationships: relsActionFor(feedMetricTypeOfResourceTypeUrl)
                 });
                 factory.ResourceOfType = $resource(url + '/resourceTypes/:resourceTypeId/resources');
                 factory.ResourceOfTypeUnderFeed =
-                    $resource(url + '/:environmentId/:feedId/resourceTypes/:resourceTypeId/resources');
+                    $resource(url + '/feeds/:feedId/resourceTypes/:resourceTypeId/resources');
                 factory.ResourceRecursiveChildren = $resource(url + '/:environmentId/resources/:resourcePath/recursiveChildren');
                 factory.ResourceRecursiveChildrenUnderFeed =
-                    $resource(url + '/:environmentId/:feedId/resources/:resourcePath/recursiveChildren');
+                    $resource(url + '/feeds/:feedId/resources/:resourcePath/recursiveChildren');
                 var metricUrl = url + '/:environmentId/metrics/:metricId';
                 factory.Metric = $resource(metricUrl, null, {
                     put: {
@@ -445,7 +445,7 @@ var hawkularRest;
                     },
                     relationships: relsActionFor(metricUrl)
                 });
-                var feedMetricUrl = url + '/:environmentId/:feedId/metrics/:metricId';
+                var feedMetricUrl = url + '/feeds/:feedId/metrics/:metricId';
                 factory.MetricUnderFeed = $resource(feedMetricUrl, null, {
                     put: {
                         method: 'PUT'

--- a/dist/hawkular-ui-service.min.js
+++ b/dist/hawkular-ui-service.min.js
@@ -383,7 +383,7 @@ var hawkularRest;
                     },
                     relationships: relsActionFor(environmentUrl)
                 });
-                var feedUrl = url + '/:environmentId/feeds/:feedId';
+                var feedUrl = url + '/feeds/:feedId';
                 factory.Feed = $resource(feedUrl, null, {
                     put: {
                         method: 'PUT'
@@ -392,11 +392,11 @@ var hawkularRest;
                 });
                 var resourceUrl = url + '/:environmentId/resources/:resourcePath';
                 factory.Resource = $resource(resourceUrl, null, createResourceActions(resourceUrl, 'configuration'));
-                var feedResourceUrl = url + '/:environmentId/:feedId/resources/:resourcePath';
+                var feedResourceUrl = url + '/feeds/:feedId/resources/:resourcePath';
                 factory.ResourceUnderFeed = $resource(feedResourceUrl, null, createResourceActions(feedResourceUrl, 'configuration'));
                 var resourceTypeUrl = url + '/resourceTypes/:resourceTypeId';
                 factory.ResourceType = $resource(resourceTypeUrl, null, createDataActions(resourceTypeUrl, 'configurationSchema'));
-                var feedResourceTypeUrl = url + '/:environmentId/:feedId/resourceTypes/:resourceTypeId';
+                var feedResourceTypeUrl = url + '/feeds/:feedId/resourceTypes/:resourceTypeId';
                 factory.ResourceTypeUnderFeed = $resource(feedResourceTypeUrl, null, createDataActions(feedResourceTypeUrl, 'configurationSchema'));
                 var metricTypeUrl = url + '/metricTypes/:metricTypeId';
                 factory.MetricType = $resource(metricTypeUrl, null, {
@@ -405,7 +405,7 @@ var hawkularRest;
                     },
                     relationships: relsActionFor(metricTypeUrl)
                 });
-                var feedMetricTypeUrl = url + '/:environmentId/:feedId/metricTypes/:metricTypeId';
+                var feedMetricTypeUrl = url + '/feeds/:feedId/metricTypes/:metricTypeId';
                 factory.MetricTypeUnderFeed = $resource(feedMetricTypeUrl, null, {
                     put: {
                         method: 'PUT'
@@ -418,7 +418,7 @@ var hawkularRest;
                         method: 'PUT'
                     }
                 });
-                var feedResourceMetricUrl = url + '/:environmentId/:feedId/resources/:resourcePath/metrics/:metricId';
+                var feedResourceMetricUrl = url + '/feeds/:feedId/resources/:resourcePath/metrics/:metricId';
                 factory.MetricOfResourceUnderFeed = $resource(resourceMetricUrl, null, {
                     put: {
                         method: 'PUT'
@@ -428,16 +428,16 @@ var hawkularRest;
                 factory.MetricTypeOfResourceType = $resource(metricTypeOfResourceTypeUrl, null, {
                     relationships: relsActionFor(metricTypeOfResourceTypeUrl)
                 });
-                var feedMetricTypeOfResourceTypeUrl = url + '/:environmentId/:feedId/resourceTypes/:resourceTypeId/metricTypes/:metricTypeId';
+                var feedMetricTypeOfResourceTypeUrl = url + '/feeds/:feedId/resourceTypes/:resourceTypeId/metricTypes/:metricTypeId';
                 factory.MetricTypeOfResourceTypeUnderFeed = $resource(feedMetricTypeOfResourceTypeUrl, null, {
                     relationships: relsActionFor(feedMetricTypeOfResourceTypeUrl)
                 });
                 factory.ResourceOfType = $resource(url + '/resourceTypes/:resourceTypeId/resources');
                 factory.ResourceOfTypeUnderFeed =
-                    $resource(url + '/:environmentId/:feedId/resourceTypes/:resourceTypeId/resources');
+                    $resource(url + '/feeds/:feedId/resourceTypes/:resourceTypeId/resources');
                 factory.ResourceRecursiveChildren = $resource(url + '/:environmentId/resources/:resourcePath/recursiveChildren');
                 factory.ResourceRecursiveChildrenUnderFeed =
-                    $resource(url + '/:environmentId/:feedId/resources/:resourcePath/recursiveChildren');
+                    $resource(url + '/feeds/:feedId/resources/:resourcePath/recursiveChildren');
                 var metricUrl = url + '/:environmentId/metrics/:metricId';
                 factory.Metric = $resource(metricUrl, null, {
                     put: {
@@ -445,7 +445,7 @@ var hawkularRest;
                     },
                     relationships: relsActionFor(metricUrl)
                 });
-                var feedMetricUrl = url + '/:environmentId/:feedId/metrics/:metricId';
+                var feedMetricUrl = url + '/feeds/:feedId/metrics/:metricId';
                 factory.MetricUnderFeed = $resource(feedMetricUrl, null, {
                     put: {
                         method: 'PUT'

--- a/src/rest/hawkRest-inventory-provider.spec.rest.js
+++ b/src/rest/hawkRest-inventory-provider.spec.rest.js
@@ -299,8 +299,6 @@ describe('Provider: Hawkular live REST', function() {
           expect(result.length).toEqual(2);
           expect(result[0].id).toEqual(rId31);
           expect(result[1].id).toEqual(rId32);
-          expect(result[0].environmentId).toEqual(eId);
-          expect(result[1].environmentId).toEqual(eId);
         });
       });
 

--- a/src/rest/hawkRest-inventory-provider.ts
+++ b/src/rest/hawkRest-inventory-provider.ts
@@ -138,7 +138,7 @@ module hawkularRest {
 
       // ngResources
       // Often there are X and XUnderFeed variants, this is because of the fact that inventory
-      // allows to store the entities in the graph db either under the environment of under the feed
+      // allows to store the entities in the graph db either under the environment or under the feed
       // that is also under the environment. In a way, entities under the feeds allow for finer grade
       // structure, while things stored under environment are more suitable for things shared across
       // multiple feeds (note: name must be unique within the parent node (feed/environment)).
@@ -160,7 +160,7 @@ module hawkularRest {
       });
 
       // Feeds CRUD
-      var feedUrl = url + '/:environmentId/feeds/:feedId';
+      var feedUrl = url + '/feeds/:feedId';
       factory.Feed = $resource(feedUrl, null, {
         put: {
           method: 'PUT'
@@ -173,7 +173,7 @@ module hawkularRest {
       factory.Resource = $resource(resourceUrl, null, createResourceActions(resourceUrl, 'configuration'));
 
       // Resources located under the feed CRUD
-      var feedResourceUrl = url + '/:environmentId/:feedId/resources/:resourcePath';
+      var feedResourceUrl = url + '/feeds/:feedId/resources/:resourcePath';
       factory.ResourceUnderFeed = $resource(feedResourceUrl, null,
         createResourceActions(feedResourceUrl, 'configuration'));
 
@@ -182,7 +182,7 @@ module hawkularRest {
       factory.ResourceType = $resource(resourceTypeUrl, null,
         createDataActions(resourceTypeUrl, 'configurationSchema'));
 
-      var feedResourceTypeUrl = url + '/:environmentId/:feedId/resourceTypes/:resourceTypeId';
+      var feedResourceTypeUrl = url + '/feeds/:feedId/resourceTypes/:resourceTypeId';
       factory.ResourceTypeUnderFeed = $resource(feedResourceTypeUrl, null,
         createDataActions(feedResourceTypeUrl, 'configurationSchema'));
 
@@ -195,7 +195,7 @@ module hawkularRest {
         relationships: relsActionFor(metricTypeUrl)
       });
 
-      var feedMetricTypeUrl = url + '/:environmentId/:feedId/metricTypes/:metricTypeId';
+      var feedMetricTypeUrl = url + '/feeds/:feedId/metricTypes/:metricTypeId';
       factory.MetricTypeUnderFeed = $resource(feedMetricTypeUrl, null, {
         put: {
           method: 'PUT'
@@ -211,7 +211,7 @@ module hawkularRest {
         }
       });
 
-      var feedResourceMetricUrl = url + '/:environmentId/:feedId/resources/:resourcePath/metrics/:metricId';
+      var feedResourceMetricUrl = url + '/feeds/:feedId/resources/:resourcePath/metrics/:metricId';
       factory.MetricOfResourceUnderFeed = $resource(resourceMetricUrl, null, {
         put: {
           method: 'PUT'
@@ -225,7 +225,7 @@ module hawkularRest {
       });
 
       var feedMetricTypeOfResourceTypeUrl =
-        url + '/:environmentId/:feedId/resourceTypes/:resourceTypeId/metricTypes/:metricTypeId';
+        url + '/feeds/:feedId/resourceTypes/:resourceTypeId/metricTypes/:metricTypeId';
       factory.MetricTypeOfResourceTypeUnderFeed = $resource(feedMetricTypeOfResourceTypeUrl, null, {
         relationships: relsActionFor(feedMetricTypeOfResourceTypeUrl)
       });
@@ -233,7 +233,7 @@ module hawkularRest {
       // Resources of a given type
       factory.ResourceOfType = $resource(url + '/resourceTypes/:resourceTypeId/resources');
       factory.ResourceOfTypeUnderFeed =
-        $resource(url + '/:environmentId/:feedId/resourceTypes/:resourceTypeId/resources');
+        $resource(url + '/feeds/:feedId/resourceTypes/:resourceTypeId/resources');
 
       // Returns all the resources under the resource given by the :resourcePath respecting the resource hierarchy
       // ?typeId=fooResourceType query param can be used
@@ -242,7 +242,7 @@ module hawkularRest {
       // same as ^ but it's for the resources under the feed additional optional query param called 'feedlessType'
       // can be used. It denotes whether to use the resource type located under the env (true) or not which is default
       factory.ResourceRecursiveChildrenUnderFeed =
-      $resource(url + '/:environmentId/:feedId/resources/:resourcePath/recursiveChildren');
+      $resource(url + '/feeds/:feedId/resources/:resourcePath/recursiveChildren');
 
       // Metrics      
       var metricUrl = url + '/:environmentId/metrics/:metricId';
@@ -253,7 +253,7 @@ module hawkularRest {
         relationships: relsActionFor(metricUrl)
       });
 
-      var feedMetricUrl = url + '/:environmentId/:feedId/metrics/:metricId';
+      var feedMetricUrl = url + '/feeds/:feedId/metrics/:metricId';
       factory.MetricUnderFeed = $resource(feedMetricUrl, null, {
         put: {
           method: 'PUT'


### PR DESCRIPTION
This shouldn't break anything in the hawkular console, because even the environmentId params are still passed from the console when calling this ngResource, they are appended as a query params and ignored by the rest easy. I am not saying that's perfect, but it doesn't require any special synchronization of pull requests to hawkular/ui-services and hawkular/hawkular.

@mtho11 Should I push also the `/dist/*` stuff and increase the version? I thought, we shouldn't do that, but the last commit (a6f82dcba5) does that (the dist/\* part), so I am asking.
