### PR TITLE
Revert wrong GET url for single alert

### DIFF
--- a/src/rest/hawkRest-alert-provider.ts
+++ b/src/rest/hawkRest-alert-provider.ts
@@ -51,7 +51,7 @@ module hawkularRest {
       var prefix = this.protocol + '://' + this.host + ':' + this.port;
       var factory: any = {};
 
-      factory.Alert = $resource(prefix + '/hawkular/alerts', {
+      factory.Alert = $resource(prefix + '/hawkular/alerts/alert/:alertId', {
         alertId: '@alertId'
       }, {
         query: {


### PR DESCRIPTION
Fixing tests I left a bad url on the factory.
Not used on tests, but used on alertManager.ts.
