### PR TITLE
Slash hell: Preserving the encoded slashes in the resource ids. 

### DIFF
--- a/src/rest/hawkRest-inventory-provider.ts
+++ b/src/rest/hawkRest-inventory-provider.ts
@@ -23,11 +23,12 @@
 
 module hawkularRest {
 
-  _module.constant("inventoryInterceptURLS",
-      [new RegExp('.+/inventory/.+/resources/.+%2F.+')]);
+  _module.constant('inventoryInterceptURLS',
+      [new RegExp('.+/inventory/.+/resources/.+%2F.+'), new RegExp('.+/inventory/.+/resources/.+%252F.+')]);
 
   _module.config(['$httpProvider', 'inventoryInterceptURLS', function($httpProvider, inventoryInterceptURLS) {
-    var ENCODED_SLASH = new RegExp("%2F", 'g');
+    var ENCODED_SLASH = new RegExp('%2F', 'g');
+    var DOUBLE_ENCODED_SLASH = new RegExp('%252F', 'g');
 
     $httpProvider.interceptors.push(function ($q) {
       return {
@@ -37,7 +38,8 @@ module hawkularRest {
           for (var i = 0; i < inventoryInterceptURLS.length; i++) {
 
             if (url.match(inventoryInterceptURLS[i])) {
-              url = url.replace(ENCODED_SLASH, "/");
+              // first step: %2F -> / ; second step: %252F -> %2F (the order is important here)
+              url = url.replace(ENCODED_SLASH, '/').replace(DOUBLE_ENCODED_SLASH, ENCODED_SLASH);
               // end there is only one matching url
               break;
             }


### PR DESCRIPTION
Currently the interceptor replaces all the encoded slashes to the simple ones, but we need to have the way to pass the encoded slash in the resource id. If the resource id is manually encoded with window.encodeURI() and then angular does it once more for the 'percent' symbol, it ends up as '%252F' here we turn it back to simple '%2F' for which the inventory backend is prepared. In short: '/' are allowed as resource separators: r1/r2/r3 and '%2F' are allowed in the resource ids: r%2F1/r%2F2

@ammendonca could you please check?
