### PR TITLE
Fix to double encoded slash, was replacing with RegExp value

### DIFF
--- a/dist/hawkular-ui-service.js
+++ b/dist/hawkular-ui-service.js
@@ -282,17 +282,20 @@ var hawkularRest;
 /// limitations under the License.
 var hawkularRest;
 (function (hawkularRest) {
-    hawkularRest._module.constant('inventoryInterceptURLS', [new RegExp('.+/inventory/.+/resources/.+%2F.+'), new RegExp('.+/inventory/.+/resources/.+%252F.+')]);
+    hawkularRest._module.constant('inventoryInterceptURLS', [new RegExp('.+/inventory/.+/resources/.+%2F.+', 'i'), new RegExp('.+/inventory/.+/resources/.+%252F.+', 'i')]);
     hawkularRest._module.config(['$httpProvider', 'inventoryInterceptURLS', function ($httpProvider, inventoryInterceptURLS) {
-            var ENCODED_SLASH = new RegExp('%2F', 'gi');
-            var DOUBLE_ENCODED_SLASH = new RegExp('%252F', 'gi');
+            var SLASH = '/';
+            var ENCODED_SLASH = '%2F';
+            var ENCODED_SLASH_RE = new RegExp(ENCODED_SLASH, 'gi');
+            var DOUBLE_ENCODED_SLASH = '%252F';
+            var DOUBLE_ENCODED_SLASH_RE = new RegExp(DOUBLE_ENCODED_SLASH, 'gi');
             $httpProvider.interceptors.push(function ($q) {
                 return {
                     'request': function (config) {
                         var url = config.url;
                         for (var i = 0; i < inventoryInterceptURLS.length; i++) {
                             if (url.match(inventoryInterceptURLS[i])) {
-                                url = url.replace(ENCODED_SLASH, '/').replace(DOUBLE_ENCODED_SLASH, ENCODED_SLASH);
+                                url = url.replace(ENCODED_SLASH_RE, SLASH).replace(DOUBLE_ENCODED_SLASH_RE, ENCODED_SLASH);
                                 break;
                             }
                         }

--- a/dist/hawkular-ui-service.min.js
+++ b/dist/hawkular-ui-service.min.js
@@ -282,17 +282,20 @@ var hawkularRest;
 /// limitations under the License.
 var hawkularRest;
 (function (hawkularRest) {
-    hawkularRest._module.constant('inventoryInterceptURLS', [new RegExp('.+/inventory/.+/resources/.+%2F.+'), new RegExp('.+/inventory/.+/resources/.+%252F.+')]);
+    hawkularRest._module.constant('inventoryInterceptURLS', [new RegExp('.+/inventory/.+/resources/.+%2F.+', 'i'), new RegExp('.+/inventory/.+/resources/.+%252F.+', 'i')]);
     hawkularRest._module.config(['$httpProvider', 'inventoryInterceptURLS', function ($httpProvider, inventoryInterceptURLS) {
-            var ENCODED_SLASH = new RegExp('%2F', 'gi');
-            var DOUBLE_ENCODED_SLASH = new RegExp('%252F', 'gi');
+            var SLASH = '/';
+            var ENCODED_SLASH = '%2F';
+            var ENCODED_SLASH_RE = new RegExp(ENCODED_SLASH, 'gi');
+            var DOUBLE_ENCODED_SLASH = '%252F';
+            var DOUBLE_ENCODED_SLASH_RE = new RegExp(DOUBLE_ENCODED_SLASH, 'gi');
             $httpProvider.interceptors.push(function ($q) {
                 return {
                     'request': function (config) {
                         var url = config.url;
                         for (var i = 0; i < inventoryInterceptURLS.length; i++) {
                             if (url.match(inventoryInterceptURLS[i])) {
-                                url = url.replace(ENCODED_SLASH, '/').replace(DOUBLE_ENCODED_SLASH, ENCODED_SLASH);
+                                url = url.replace(ENCODED_SLASH_RE, SLASH).replace(DOUBLE_ENCODED_SLASH_RE, ENCODED_SLASH);
                                 break;
                             }
                         }

--- a/src/rest/hawkRest-inventory-provider.ts
+++ b/src/rest/hawkRest-inventory-provider.ts
@@ -24,11 +24,16 @@
 module hawkularRest {
 
   _module.constant('inventoryInterceptURLS',
-      [new RegExp('.+/inventory/.+/resources/.+%2F.+'), new RegExp('.+/inventory/.+/resources/.+%252F.+')]);
+      [new RegExp('.+/inventory/.+/resources/.+%2F.+', 'i'), new RegExp('.+/inventory/.+/resources/.+%252F.+', 'i')]);
 
   _module.config(['$httpProvider', 'inventoryInterceptURLS', function($httpProvider, inventoryInterceptURLS) {
-    var ENCODED_SLASH = new RegExp('%2F', 'gi');
-    var DOUBLE_ENCODED_SLASH = new RegExp('%252F', 'gi');
+    var SLASH = '/';
+
+    var ENCODED_SLASH = '%2F';
+    var ENCODED_SLASH_RE = new RegExp(ENCODED_SLASH, 'gi');
+
+    var DOUBLE_ENCODED_SLASH = '%252F';
+    var DOUBLE_ENCODED_SLASH_RE = new RegExp(DOUBLE_ENCODED_SLASH, 'gi');
 
     $httpProvider.interceptors.push(function ($q) {
       return {
@@ -39,7 +44,7 @@ module hawkularRest {
 
             if (url.match(inventoryInterceptURLS[i])) {
               // first step: %2F -> / ; second step: %252F -> %2F (the order is important here)
-              url = url.replace(ENCODED_SLASH, '/').replace(DOUBLE_ENCODED_SLASH, ENCODED_SLASH);
+              url = url.replace(ENCODED_SLASH_RE, SLASH).replace(DOUBLE_ENCODED_SLASH_RE, ENCODED_SLASH);
               // end there is only one matching url
               break;
             }


### PR DESCRIPTION
There was a issue where "%252F" was being replace with the actual value
of the regexp "/%2F/gi" and not the string "%2F" itself.

Externalized strings and regexp to vars and also made the URL matching
case insensitive.
