### PR TITLE
Inventory events

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,8 @@
     "hawkular-ui"
   ],
   "main": [
-    "dist/hawkular-ui-service.js"
+    "dist/hawkular-ui-service.js",
+    "dist/defs/hawkRest.d.ts"
   ],
   "ignore": [
     "*",

--- a/gulp/scripts.js
+++ b/gulp/scripts.js
@@ -1,13 +1,27 @@
 'use strict';
 
-import  gulp from 'gulp';
+import gulp from 'gulp';
 import tslintRules from '../tslint.json';
+import merge from 'merge2';
 
 const paths = gulp.paths;
 
 const $ = require('gulp-load-plugins')({
   pattern: ['gulp-*', 'del']
 });
+
+const config = {
+  main: '.',
+  ts: ['src/**/*.ts'],
+  tsProject: $.typescript.createProject({
+    target: 'ES5',
+    module: 'commonjs',
+    declaration: true,
+    removeComments: true,
+    noExternalResolve: false
+  })
+};
+
 
 gulp.task('tslint', function () {
   gulp.src([paths.src + '/hawkRest.ts', paths.src + '/hawkRest-*.ts'])
@@ -21,20 +35,20 @@ gulp.task('scripts', function () {
 
   const license = tslintRules.rules['license-header'][1];
 
-  return gulp.src([paths.src + '/hawkRest.ts', paths.src + '/hawkRest-*.ts'])
-    .pipe($.typescript({
-      removeComments: true
-    }))
+  const tsResult = gulp.src([paths.src + '/hawkRest.ts', paths.src + '/hawkRest*.ts'])
+    .pipe($.typescript(config.tsProject))
     .on('error', function handleError(err) {
       console.error(err.toString());
       this.emit('end');
-    })
+    });
+  const jsPipe = tsResult
     .pipe($.concat('hawkular-ui-service.js'))
     .pipe($.header(license))
     .pipe(gulp.dest(paths.dist + '/'))
     .pipe($.concat('hawkular-ui-service.min.js'))
     //.pipe($.uglify())
     .pipe(gulp.dest(paths.dist + '/'));
+  return merge([tsResult.dts.pipe(gulp.dest(paths.dist + '/defs')), jsPipe]);
 });
 
 gulp.task('clean', function (done) {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "gulp-tslint": "3.3.1",
     "gulp-typescript": "2.10.0",
     "gulp-uglify": "1.5.1",
+    "merge2": "0.3.6",
     "karma-jasmine": "0.3.6",
     "karma-phantomjs-launcher": "0.2.1",
     "lodash": "3.10.1",

--- a/src/rest/hawkRest-inventory-provider.ts
+++ b/src/rest/hawkRest-inventory-provider.ts
@@ -23,13 +23,6 @@
 
 module hawkularRest {
 
-  export interface IWebSocketHandler {
-    onmessage?(json: any): void;
-    onopen? (event: any): void;
-    onclose? (event: any): void;
-    onerror? (event: any): void;
-  }
-
   _module.constant('inventoryInterceptURLS',
       [new RegExp('.+/inventory/.+/resources/.+%2F.+', 'i'), new RegExp('.+/inventory/.+/resources/.+%252F.+', 'i')]);
 
@@ -298,7 +291,8 @@ module hawkularRest {
               if (handler && handler.onmessage) {
                 handler.onmessage(eventData);
               } else {
-                $log.log('ws: received event: ' + eventData);
+                $log.log('ws: received event');
+                $log.log(eventData);
               }
             };
 

--- a/src/rest/hawkRest.ts
+++ b/src/rest/hawkRest.ts
@@ -19,4 +19,13 @@ module hawkularRest {
 
   export var _module = angular.module('hawkular.services', ['ngResource']);
 
+  // here comes type definitions and interfaces that can be reused by consumers of this module
+  // these types/ifaces can define a contract
+  export interface IWebSocketHandler {
+    onmessage?(json: any): void;
+    onopen?(event: any): void;
+    onclose?(event: any): void;
+    onerror?(event: any): void;
+  }
+
 }


### PR DESCRIPTION
Make the inventory events consumable via ui-services layer. Currently it opens a websocket connection and the client needs to add a handler with `on${x}` methods on it (`x` can be `message`, `open`, `close`, `error`)

Second commit makes the type script definitions available in the hawkular console so that we can share the types and/or interfaces across the modules and stay DRY.
