### PR TITLE
HAWKULAR-1048 fix returning array instead of Object

### DIFF
--- a/dist/hawkular-ui-service.js
+++ b/dist/hawkular-ui-service.js
@@ -415,9 +415,13 @@ var hawkularRest;
                     }
                 });
                 var feedResourceMetricUrl = url + '/feeds/:feedId/resources/:resourcePath/metrics/:metricId';
-                factory.MetricOfResourceUnderFeed = $resource(resourceMetricUrl, null, {
+                factory.MetricOfResourceUnderFeed = $resource(feedResourceMetricUrl, null, {
                     put: {
                         method: 'PUT'
+                    },
+                    'get': {
+                        method: 'GET',
+                        isArray: true
                     }
                 });
                 var metricTypeOfResourceTypeUrl = url + '/resourceTypes/:resourceTypeId/metricTypes/:metricTypeId';
@@ -433,7 +437,12 @@ var hawkularRest;
                     $resource(url + '/feeds/:feedId/resourceTypes/:resourceTypeId/resources');
                 factory.ResourceRecursiveChildren = $resource(url + '/:environmentId/resources/:resourcePath/recursiveChildren');
                 factory.ResourceRecursiveChildrenUnderFeed =
-                    $resource(url + '/feeds/:feedId/resources/:resourcePath/recursiveChildren');
+                    $resource(url + '/feeds/:feedId/resources/:resourcePath/recursiveChildren', null, {
+                        'get': {
+                            method: 'GET',
+                            isArray: true
+                        }
+                    });
                 var metricUrl = url + '/:environmentId/metrics/:metricId';
                 factory.Metric = $resource(metricUrl, null, {
                     put: {

--- a/dist/hawkular-ui-service.min.js
+++ b/dist/hawkular-ui-service.min.js
@@ -415,9 +415,13 @@ var hawkularRest;
                     }
                 });
                 var feedResourceMetricUrl = url + '/feeds/:feedId/resources/:resourcePath/metrics/:metricId';
-                factory.MetricOfResourceUnderFeed = $resource(resourceMetricUrl, null, {
+                factory.MetricOfResourceUnderFeed = $resource(feedResourceMetricUrl, null, {
                     put: {
                         method: 'PUT'
+                    },
+                    'get': {
+                        method: 'GET',
+                        isArray: true
                     }
                 });
                 var metricTypeOfResourceTypeUrl = url + '/resourceTypes/:resourceTypeId/metricTypes/:metricTypeId';
@@ -433,7 +437,12 @@ var hawkularRest;
                     $resource(url + '/feeds/:feedId/resourceTypes/:resourceTypeId/resources');
                 factory.ResourceRecursiveChildren = $resource(url + '/:environmentId/resources/:resourcePath/recursiveChildren');
                 factory.ResourceRecursiveChildrenUnderFeed =
-                    $resource(url + '/feeds/:feedId/resources/:resourcePath/recursiveChildren');
+                    $resource(url + '/feeds/:feedId/resources/:resourcePath/recursiveChildren', null, {
+                        'get': {
+                            method: 'GET',
+                            isArray: true
+                        }
+                    });
                 var metricUrl = url + '/:environmentId/metrics/:metricId';
                 factory.Metric = $resource(metricUrl, null, {
                     put: {

--- a/src/rest/hawkRest-inventory-provider.ts
+++ b/src/rest/hawkRest-inventory-provider.ts
@@ -264,7 +264,12 @@ module hawkularRest {
       // same as ^ but it's for the resources under the feed additional optional query param called 'feedlessType'
       // can be used. It denotes whether to use the resource type located under the env (true) or not which is default
       factory.ResourceRecursiveChildrenUnderFeed =
-      $resource(url + '/feeds/:feedId/resources/:resourcePath/recursiveChildren');
+      $resource(url + '/feeds/:feedId/resources/:resourcePath/recursiveChildren', null, {
+        'get':  {
+          method:'GET',
+          isArray:true
+        }
+      });
 
       // Metrics
       var metricUrl = url + '/:environmentId/metrics/:metricId';


### PR DESCRIPTION
If array but the request return Object, the request is thrown away. So change ResourceRecursiveChildrenUnderFeed method to return array on GET requests.
